### PR TITLE
docs: fix module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install ng13-rut --save
 
 ### Set-up:
 
-The easiest way to use this library is to import Ng13Rut in your app's main module.
+The easiest way to use this library is to import `Ng13RutModule` in your app's main module.
 
 ```typescript
 import { NgModule } from '@angular/core';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng13-rut",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/bglamadrid/ng13-rut#README.md",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This just fixes a little doc typo. Plus I update the patch version, since I'm grouping this with an fixed link to the npm package page. A minor patch, really.